### PR TITLE
Retry if the future itself fails

### DIFF
--- a/core/src/main/scala/retries.scala
+++ b/core/src/main/scala/retries.scala
@@ -57,12 +57,14 @@ trait CountingRetry {
                          promise: () => Future[T],
                          success: Success[T],
                          orElse: Int => Future[T]
-                       )(implicit executor: ExecutionContext) = {
+                       )(implicit executor: ExecutionContext): Future[T] = {
     val fut = promise()
     fut.flatMap { res =>
       if (max < 1 || success.predicate(res)) fut
-      else orElse(max - 1)
-    }
+      else orElse(max - 1)    
+    } recoverWith {
+      case e: Throwable => if (max < 1) fut else orElse(max - 1)
+    }    
   }
 }
 


### PR DESCRIPTION
I often get bitten by the fact that the retry logic will not retry if an exception gets thrown within the body of the future. The workaround I have been using in the past is to have the future wrap a `scala.util.Try`. Doing so works, but is unnecessary since `Try` is already incorporated into `scala.concurrent.Future` (see `Future.onComplete`, for instance). So having to deal with a `Future[Try[T]]` is a little redundant and unnecessarily cumbersome. 

As a solution, I added a simple `recoverWith` block that will perform a retry (and decrement the max retries) if the future fails. I also added a unit test
