### PR TITLE
Fixed Defaults.jitter

### DIFF
--- a/shared/src/main/scala/Defaults.scala
+++ b/shared/src/main/scala/Defaults.scala
@@ -6,8 +6,8 @@ import java.util.concurrent.{ ThreadLocalRandom, TimeUnit }
 object Defaults {
   val delay: FiniteDuration = Duration(500, TimeUnit.MILLISECONDS)
   val cap: FiniteDuration = Duration(1, TimeUnit.MINUTES)
-  val jitter = Jitter.full()
   val random: Jitter.RandomSource =
     Jitter.randomSource(ThreadLocalRandom.current())
+  val jitter = Jitter.full()
 }
 

--- a/shared/src/test/scala/JitterSpec.scala
+++ b/shared/src/test/scala/JitterSpec.scala
@@ -84,4 +84,10 @@ class JitterSpec extends FunSpec {
       testJitter(Jitter.equal(cap))
     }
   }
+
+  describe("retry.Defaults.jitter") {
+    it("should work") {
+      assert(Defaults.jitter(100.millis, 300.millis, 3) <= Defaults.cap)
+    }
+  }
 }


### PR DESCRIPTION
`Defaults.random` should be defined before `Defaults.jitter`
because `Defaults.jitter` refers `Defaults.random`.

Fixes #28