### PR TITLE
Support Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 val scala211 = "2.11.12"
 val scala212 = "2.12.12"
 val scala213 = "2.13.2"
+val scala30 = "3.0.0"
 
 val commonSettings = commonSmlBuildSettings ++ ossPublishSettings
 
@@ -13,14 +14,14 @@ lazy val retry = (projectMatrix in file("retry"))
     name := "retry",
     description := "a library of simple primitives for asynchronously retrying Scala Futures",
     libraryDependencies ++=
-      Seq("org.scalatest" %%% "scalatest" % "3.1.4" % "test",
-        "com.softwaremill.odelay" %%% "odelay-core" % "0.3.2",
-        "org.scala-lang.modules" %%% "scala-collection-compat" % "2.1.6"
+      Seq("org.scalatest" %%% "scalatest" % "3.2.9" % "test",
+        "com.softwaremill.odelay" %%% "odelay-core" % "0.3.3",
+        "org.scala-lang.modules" %%% "scala-collection-compat" % "2.6.0"
       )
   )
   .jvmPlatform(
-    scalaVersions = List(scala211, scala212, scala213)
+    scalaVersions = List(scala211, scala212, scala213, scala30)
   )
   .jsPlatform(
-    scalaVersions = List(scala212, scala213)
+    scalaVersions = List(scala212, scala213, scala30)
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.7.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.9.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.3")
 
 val sbtSoftwaremillVersion = "1.9.15"
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-common" % sbtSoftwaremillVersion)

--- a/retry/src/main/scala/Policy.scala
+++ b/retry/src/main/scala/Policy.scala
@@ -29,11 +29,11 @@ object Directly {
           implicit success: Success[T],
           executor: ExecutionContext): Future[T] = {
         def run(): Future[T] = {
-          retry(promise, run, { _: Future[T] =>
+          retry(promise, run, { (_: Future[T]) =>
             run()
           })
         }
-        run
+        run()
       }
     }
 
@@ -61,7 +61,7 @@ object Pause {
         def run(): Future[T] = {
           val nextRun: () => Future[T] = () =>
             Delay(delay)(run()).future.flatMap(identity)
-          retry(promise, nextRun, { _: Future[T] =>
+          retry(promise, nextRun, { (_: Future[T]) =>
             nextRun()
           })
         }
@@ -131,7 +131,7 @@ object JitterBackoff {
             Delay(delay) {
               run(attempt + 1, jitter(delay, sleep, attempt))
             }.future.flatMap(identity)
-          retry(promise, nextRun, { _: Future[T] =>
+          retry(promise, nextRun, { (_: Future[T]) =>
             nextRun()
           })
         }
@@ -173,7 +173,7 @@ object Backoff {
             Delay(delay) {
               run(Duration(delay.length * base, delay.unit))
             }.future.flatMap(identity)
-          retry(promise, nextRun, { _: Future[T] =>
+          retry(promise, nextRun, { (_: Future[T]) =>
             nextRun()
           })
         }
@@ -246,7 +246,7 @@ trait CountingPolicy extends Policy {
     // consider this successful if our predicate says so _or_
     // we've reached the end out our countdown
     val countedSuccess = success.or(max < 1)
-    retry(promise, () => orElse(max - 1), { f: Future[T] =>
+    retry(promise, () => orElse(max - 1), { (f: Future[T]) =>
       if (max < 1) f else orElse(max - 1)
     })(countedSuccess, executor)
   }

--- a/retry/src/test/scala/JitterSpec.scala
+++ b/retry/src/test/scala/JitterSpec.scala
@@ -4,17 +4,17 @@ import java.util.Random
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import scala.concurrent.duration._
 
-class JitterSpec extends FunSpec {
+class JitterSpec extends AnyFunSpec {
   val rng = new java.util.Random()
   val rand = Jitter.randomSource(rng)
-  val cap = 2000 milliseconds
+  val cap = 2000.millis
 
   def testJitter(jitter: Jitter)(): Unit = {
-    val min = rand(1, 100) milliseconds
-    var sleep = rand(1, 1000) milliseconds
+    val min = rand(1, 100).millis
+    var sleep = rand(1, 1000).millis
 
     for (i <- 0 until 10000) {
       val delay = sleep
@@ -60,25 +60,25 @@ class JitterSpec extends FunSpec {
 
   describe("retry.Jitter.none") {
     it("should perform backoff correctly") {
-      testJitter(Jitter.none(cap))
+      testJitter(Jitter.none(cap))()
     }
   }
 
   describe("retry.Jitter.decorrelated") {
     it("should perform decorrelated jitter correctly") {
-      testJitter(Jitter.decorrelated(cap))
+      testJitter(Jitter.decorrelated(cap))()
     }
   }
 
   describe("retry.Jitter.full") {
     it("should perform full jitter correctly") {
-      testJitter(Jitter.full(cap))
+      testJitter(Jitter.full(cap))()
     }
   }
 
   describe("retry.Jitter.equal") {
     it("should perform equal jitter correctly") {
-      testJitter(Jitter.equal(cap))
+      testJitter(Jitter.equal(cap))()
     }
   }
 

--- a/retry/src/test/scala/SuccessSpec.scala
+++ b/retry/src/test/scala/SuccessSpec.scala
@@ -1,10 +1,10 @@
 package retry
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 import scala.util.Try
 
-class SuccessSpec extends FunSpec {
+class SuccessSpec extends AnyFunSpec {
   describe("retry.Success.either") {
     val either = implicitly[Success[Either[String, String]]]
     it("should be successful on a Right") {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.4-SNAPSHOT"
+ThisBuild / version := "0.3.4-SNAPSHOT"


### PR DESCRIPTION
Title says it all.

Locally I could, `sbt "clean; +test"`

Excerpt from the scala 3 part:

```
[success] Total time: 6 s, completed Feb 14, 2022, 8:26:10 PM
[info] Setting Scala version to 3.0.0 on 2 projects.
[info] Excluded 6 projects, run ++ 3.0.0 -v for more details.
[info] Reapplying settings...
[info] set current project to default-b8b0fd (in build file:/workspace/retry/)
[info] SuccessSpec:
[info] retry.Success.either
[info] - should be successful on a Right
[info] - should be a failure on a Left
[info] retry.Success.option
[info] - should be successful on Some(_)
[info] - should be a failure on None
[info] retry.Success.tried
[info] - should be successful on Success(_)
[info] - should be failure on Failure(_)
[info] retry.Success combinators
[info] - should support and
[info] - should support or
[info] SuccessSpec:
[info] retry.Success.either
[info] - should be successful on a Right
[info] - should be a failure on a Left
[info] retry.Success.option
[info] - should be successful on Some(_)
[info] - should be a failure on None
[info] retry.Success.tried
[info] - should be successful on Success(_)
[info] - should be failure on Failure(_)
[info] retry.Success combinators
[info] - should support and
[info] - should support or
[info] JitterSpec:
[info] retry.Defaults.random
[info] - should return sane random values
[info] - should handle swapped bounds
[info] - should not cache random values
[info] retry.Jitter.none
[info] - should perform backoff correctly
[info] retry.Jitter.decorrelated
[info] - should perform decorrelated jitter correctly
[info] retry.Jitter.full
[info] - should perform full jitter correctly
[info] retry.Jitter.equal
[info] - should perform equal jitter correctly
[info] retry.Defaults.jitter
[info] - should work
[info] JitterSpec:
[info] retry.Defaults.random
[info] - should return sane random values
[info] - should handle swapped bounds
[info] - should not cache random values
[info] retry.Jitter.none
[info] - should perform backoff correctly
[info] retry.Jitter.decorrelated
[info] - should perform decorrelated jitter correctly
[info] retry.Jitter.full
[info] - should perform full jitter correctly
[info] retry.Jitter.equal
[info] - should perform equal jitter correctly
[info] retry.Defaults.jitter
[info] - should work
[info] PolicySpecJVM:
[info] retry.Directly
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should accept a future in reduced syntax format
[info] - should retry futures passed by-name instead of caching results
[info] - should repeat on not expected value until success
[info] retry.Pause
[info] - should pause in between retries
[info] - should repeat on unexpected value with pause until success
[info] retry.Backoff
[info] - should pause with multiplier between retries
[info] - should repeat on unexpected value with backoff until success
[info] retry.JitterBackoff.none
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should retry futures passed by-name instead of caching results
[info] - should pause with multiplier and jitter between retries
[info] - should also work when invoked as forever
[info] - should repeat on unexpected value with jitter backoff until success
[info] retry.JitterBackoff.full
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should retry futures passed by-name instead of caching results
[info] - should pause with multiplier and jitter between retries
[info] - should also work when invoked as forever
[info] - should repeat on unexpected value with jitter backoff until success
[info] retry.JitterBackoff.equal
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should retry futures passed by-name instead of caching results
[info] - should pause with multiplier and jitter between retries
[info] - should also work when invoked as forever
[info] - should repeat on unexpected value with jitter backoff until success
[info] retry.JitterBackoff.decorrelated
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should retry futures passed by-name instead of caching results
[info] - should pause with multiplier and jitter between retries
[info] - should also work when invoked as forever
[info] - should repeat on unexpected value with jitter backoff until success
[info] retry.When
[info] - should retry conditionally when a condition is met
[info] - should retry but only when condition is met
[info] - should handle future failures
[info] - should repeat on failure until success
[info] - should repeat on failure with pause until success
[info] - should repeat on failure with backoff until success
[info] - should repeat on failure with jitter backoff until success
[info] Run completed in 5 seconds, 227 milliseconds.
[info] Total number of tests run: 61
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 61, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] PolicySpecJS:
[info] retry.Directly
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should accept a future in reduced syntax format
[info] - should retry futures passed by-name instead of caching results
[info] - should repeat on not expected value until success
[info] retry.Pause
[info] - should pause in between retries
[info] - should repeat on unexpected value with pause until success
[info] retry.Backoff
[info] - should pause with multiplier between retries
[info] - should repeat on unexpected value with backoff until success
[info] retry.JitterBackoff.none
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should retry futures passed by-name instead of caching results
[info] - should pause with multiplier and jitter between retries
[info] - should also work when invoked as forever
[info] - should repeat on unexpected value with jitter backoff until success
[info] retry.JitterBackoff.full
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should retry futures passed by-name instead of caching results
[info] - should pause with multiplier and jitter between retries
[info] - should also work when invoked as forever
[info] - should repeat on unexpected value with jitter backoff until success
[info] retry.JitterBackoff.equal
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should retry futures passed by-name instead of caching results
[info] - should pause with multiplier and jitter between retries
[info] - should also work when invoked as forever
[info] - should repeat on unexpected value with jitter backoff until success
[info] retry.JitterBackoff.decorrelated
[info] - should retry a future for a specified number of times
[info] - should fail when expected
[info] - should deal with future failures
[info] - should retry futures passed by-name instead of caching results
[info] - should pause with multiplier and jitter between retries
[info] - should also work when invoked as forever
[info] - should repeat on unexpected value with jitter backoff until success
[info] retry.When
[info] - should retry conditionally when a condition is met
[info] - should retry but only when condition is met
[info] - should handle future failures
[info] - should repeat on failure until success
[info] - should repeat on failure with pause until success
[info] - should repeat on failure with backoff until success
[info] - should repeat on failure with jitter backoff until success
[info] Run completed in 5 seconds, 159 milliseconds.
[info] Total number of tests run: 61
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 61, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 6 s, completed Feb 14, 2022, 8:26:17 PM
```