### PR TITLE
Removed the travis-ci.org build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # retry
 
-[![Build Status](https://travis-ci.org/softwaremill/retry.png?branch=master)](https://travis-ci.org/softwaremill/retry)
-
 don't give up
 
 ## install


### PR DESCRIPTION
The free CI from Travis has been unavailable since 2020 or 2021 anyway.